### PR TITLE
Migrate to Spectre.Console.Cli

### DIFF
--- a/src/net-extras/ConsoleClient/ConsoleClient.csproj
+++ b/src/net-extras/ConsoleClient/ConsoleClient.csproj
@@ -13,8 +13,9 @@
       <PackageReference Include="Serilog" Version="2.11.0" />
       <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
       <PackageReference Include="Serilog.Sinks.Spectre" Version="0.3.1" />
-      <PackageReference Include="Spectre.Cli.Extensions.DependencyInjection" Version="0.4.0" />
-      <PackageReference Include="Spectre.Console" Version="0.44.0" />
+      <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />
+      <PackageReference Include="Spectre.Console" Version="0.45.0" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/net-extras/ConsoleClient/Program.cs
+++ b/src/net-extras/ConsoleClient/Program.cs
@@ -8,7 +8,7 @@ using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.Spectre;
 using ServerServices;
-using Spectre.Cli.Extensions.DependencyInjection;
+using Spectre.Console.Cli.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 using System.IO;
 


### PR DESCRIPTION
Spectre.Console has removed CLI functions into its own Spectre.Console.Cli NuGet package, this PR addresses the changes needed to be able to adopt the latest Spectre.Console version.

* Update Spectre.Console to 0.45.0
* Add Spectre.Console.Cli 0.45.0
* Migrate from Spectre.Cli.Extensions.DependencyInjection to Spectre.Console.Cli.Extensions.DependencyInjection